### PR TITLE
Add pagination to recommended items section

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -61,7 +61,7 @@ function getPageUrl(page: number): string {
     {/* Previous button */}
     {currentPage > 1 && (
       <a href={getPageUrl(currentPage - 1)} class="pagination-btn prev">
-        <i class="fa-solid fa-chevron-left"></i>
+        <i class="fa-sharp fa-solid fa-chevron-left"></i>
         Previous
       </a>
     )}
@@ -86,7 +86,7 @@ function getPageUrl(page: number): string {
     {currentPage < totalPages && (
       <a href={getPageUrl(currentPage + 1)} class="pagination-btn next">
         Next
-        <i class="fa-solid fa-chevron-right"></i>
+        <i class="fa-sharp fa-solid fa-chevron-right"></i>
       </a>
     )}
   </div>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,178 @@
+---
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  baseUrl: string;
+}
+
+const { currentPage, totalPages, baseUrl } = Astro.props;
+
+// Generate page numbers to display
+function getPageNumbers(current: number, total: number): (number | string)[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  
+  const pages: (number | string)[] = [];
+  
+  // Always show first page
+  pages.push(1);
+  
+  if (current <= 4) {
+    // Show first 5 pages
+    for (let i = 2; i <= Math.min(5, total); i++) {
+      pages.push(i);
+    }
+    if (total > 5) {
+      pages.push('...');
+      pages.push(total);
+    }
+  } else if (current >= total - 3) {
+    // Show last 5 pages
+    pages.push('...');
+    for (let i = Math.max(2, total - 4); i <= total; i++) {
+      pages.push(i);
+    }
+  } else {
+    // Show pages around current
+    pages.push('...');
+    for (let i = current - 1; i <= current + 1; i++) {
+      pages.push(i);
+    }
+    pages.push('...');
+    pages.push(total);
+  }
+  
+  return pages;
+}
+
+const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+function getPageUrl(page: number): string {
+  if (page === 1) {
+    return baseUrl;
+  }
+  return `${baseUrl}page/${page}/`;
+}
+---
+
+{totalPages > 1 && (
+  <div class="pagination">
+    {/* Previous button */}
+    {currentPage > 1 && (
+      <a href={getPageUrl(currentPage - 1)} class="pagination-btn prev">
+        <i class="fa-solid fa-chevron-left"></i>
+        Previous
+      </a>
+    )}
+    
+    {/* Page numbers */}
+    <div class="page-numbers">
+      {pageNumbers.map((page) => (
+        typeof page === 'number' ? (
+          <a 
+            href={getPageUrl(page)} 
+            class:list={["page-number", { active: page === currentPage }]}
+          >
+            {page}
+          </a>
+        ) : (
+          <span class="ellipsis">{page}</span>
+        )
+      ))}
+    </div>
+    
+    {/* Next button */}
+    {currentPage < totalPages && (
+      <a href={getPageUrl(currentPage + 1)} class="pagination-btn next">
+        Next
+        <i class="fa-solid fa-chevron-right"></i>
+      </a>
+    )}
+  </div>
+)}
+
+<style lang="scss">
+  .pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin-top: 40px;
+    flex-wrap: wrap;
+  }
+  
+  .pagination-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    background: var(--color-subcard-background);
+    border: 1px solid var(--color-background-dark);
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 500;
+    transition: all 0.2s;
+    
+    &:hover {
+      background: var(--color-primary);
+      color: var(--color-card-background);
+      border-color: var(--color-primary);
+    }
+    
+    i {
+      font-size: 0.8em;
+    }
+  }
+  
+  .page-numbers {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  
+  .page-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 500;
+    transition: all 0.2s;
+    border: 1px solid var(--color-background-dark);
+    
+    &:hover {
+      background: var(--color-background-light);
+    }
+    
+    &.active {
+      background: var(--color-secondary);
+      color: var(--color-card-background);
+      border-color: var(--color-secondary);
+    }
+  }
+  
+  .ellipsis {
+    padding: 0 8px;
+    color: var(--color-text-muted);
+  }
+  
+  @media screen and (max-width: 600px) {
+    .pagination {
+      gap: 6px;
+    }
+    
+    .pagination-btn {
+      padding: 8px 12px;
+      font-size: 0.9em;
+    }
+    
+    .page-number {
+      width: 36px;
+      height: 36px;
+      font-size: 0.9em;
+    }
+  }
+</style>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -67,12 +67,13 @@ function getPageUrl(page: number): string {
     )}
     
     {/* Page numbers */}
-    <div class="page-numbers">
+    <div class="page-numbers" id="page-numbers">
       {pageNumbers.map((page) => (
         typeof page === 'number' ? (
           <a 
             href={getPageUrl(page)} 
             class:list={["page-number", { active: page === currentPage }]}
+            data-page={page}
           >
             {page}
           </a>
@@ -91,6 +92,26 @@ function getPageUrl(page: number): string {
     )}
   </div>
 )}
+
+<script>
+  function centerActivePage() {
+    const pageNumbers = document.getElementById('page-numbers');
+    const activePageElement = pageNumbers?.querySelector('.page-number.active');
+    
+    if (pageNumbers && activePageElement) {
+      setTimeout(() => {
+        activePageElement.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'center'
+        });
+      }, 100);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', centerActivePage);
+  window.addEventListener('resize', centerActivePage);
+</script>
 
 <style lang="scss">
   .pagination {
@@ -129,6 +150,8 @@ function getPageUrl(page: number): string {
     display: flex;
     align-items: center;
     gap: 4px;
+    overflow-x: auto;
+    max-width: 100%;
   }
   
   .page-number {
@@ -162,17 +185,37 @@ function getPageUrl(page: number): string {
   @media screen and (max-width: 600px) {
     .pagination {
       gap: 6px;
+      flex-wrap: nowrap;
     }
     
     .pagination-btn {
       padding: 8px 12px;
       font-size: 0.9em;
+      flex-shrink: 0;
+    }
+    
+    .page-numbers {
+      overflow-x: auto;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+      flex: 1;
+      max-width: calc(100vw - 200px);
+      -webkit-overflow-scrolling: touch;
+      
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
     
     .page-number {
       width: 36px;
       height: 36px;
       font-size: 0.9em;
+      flex-shrink: 0;
+    }
+    
+    .ellipsis {
+      flex-shrink: 0;
     }
   }
 </style>

--- a/src/components/RecommendedItems.astro
+++ b/src/components/RecommendedItems.astro
@@ -11,6 +11,7 @@ import {
   getTypeTitle,
   getTagUrlFragment,
   getTagName,
+  getPaginationInfo,
 } from "@utils/recommended";
 
 const items = Enumerable.from(allMediaCollection)
@@ -59,6 +60,20 @@ const filteredItems = Enumerable.from(items)
         !tag ? 0 : i.tags!.find((t : any) => getTagName(t) === tag).rank
       )
       .thenByDescending((i) => i.date).toArray();
+
+const currentPage = page || 1;
+const paginationInfo = getPaginationInfo(filteredItems.length, currentPage, pageSize);
+
+// Build base URL for pagination
+let baseUrl = "/recommended/";
+if (type) {
+  baseUrl += `${getTypeTitle(type).toLowerCase()}/`;
+  if (tag) {
+    baseUrl += `${getTagUrlFragment(tag)}/`;
+  }
+}
+
+import Pagination from "@components/Pagination.astro";
 ---
 
 <div class="filter-bar">
@@ -103,8 +118,8 @@ const filteredItems = Enumerable.from(items)
 <div class:list={["items", (type ?? "").toLowerCase()]}>
   {
     Enumerable.from(filteredItems)
-      .skip(page > 0 ? pageSize * (page-1) : 0)
-      .take(page > 0 ? pageSize : items.length)
+      .skip(paginationInfo.startIndex)
+      .take(paginationInfo.pageSize)
       .toArray()
       .map((i, index) => {
         const large = filteredItems.length < 11 || index < 6;
@@ -160,6 +175,12 @@ const filteredItems = Enumerable.from(items)
       })
   }
 </div>
+
+<Pagination 
+  currentPage={paginationInfo.currentPage}
+  totalPages={paginationInfo.totalPages}
+  baseUrl={baseUrl}
+/>
 
 <style lang="scss">
   .items {

--- a/src/pages/recommended/[type]/[tag]/page/[page].astro
+++ b/src/pages/recommended/[type]/[tag]/page/[page].astro
@@ -1,0 +1,58 @@
+---
+import { getCollection } from "astro:content";
+import Enumerable from "linq";
+
+import { getTypeTitle, getTagUrlFragment, getTagName } from "@utils/recommended";
+
+export async function getStaticPaths() {
+  const items = await getCollection("recommendations");
+  const pageSize = 24;
+
+  const uniqueTypes = Enumerable.from(items)
+    .groupBy((i) => i.data.type)
+    .select((i) => i.first().data.type);
+
+  return uniqueTypes
+    .selectMany((type) =>
+      Enumerable.from(items)
+        .where((j) => j.data.type === type)
+        .selectMany((j) => j.data.tags as Array<string>)
+        .groupBy((j) => getTagName(j))
+        .selectMany((tagGroup) => {
+          const tag = tagGroup.key();
+          const tagItems = items.filter((i) => 
+            i.data.type === type && 
+            i.data.tags && 
+            i.data.tags.some((t: any) => getTagName(t) === tag)
+          );
+          
+          const totalPages = Math.ceil(tagItems.length / pageSize);
+          
+          return Array.from({ length: totalPages }, (_, i) => ({
+            params: {
+              type: getTypeTitle(type).toLowerCase(),
+              tag: getTagUrlFragment(tag as string),
+              page: (i + 1).toString()
+            },
+            props: { type, tag, page: i + 1 },
+          }));
+        })
+    )
+    .toArray();
+}
+
+const { type, tag, page } = Astro.props;
+
+const typeTitle = getTypeTitle(type);
+
+import RecommendedLayout from "@layouts/Recommended.astro";
+---
+
+<RecommendedLayout
+  title={`${tag} - Page ${page} | ${typeTitle} | Recommended`}
+  description={`Brian D. Adams recommendations for ${typeTitle}`}
+  sourceLink="/src/pages/recommended/[type]/[tag]/page/[page].astro"
+  type={type}
+  tag={tag}
+  page={page}
+/>

--- a/src/pages/recommended/[type]/page/[page].astro
+++ b/src/pages/recommended/[type]/page/[page].astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from "astro:content";
+import Enumerable from "linq";
+
+import { getTypeTitle } from "@utils/recommended";
+
+export async function getStaticPaths() {
+  const items = await getCollection("recommendations");
+  const pageSize = 24;
+
+  return Enumerable.from(items)
+    .groupBy((i) => i.data.type)
+    .selectMany((typeGroup) => {
+      const type = typeGroup.first().data.type;
+      const typeItems = typeGroup.toArray();
+      const totalPages = Math.ceil(typeItems.length / pageSize);
+      
+      return Array.from({ length: totalPages }, (_, i) => ({
+        params: { 
+          type: getTypeTitle(type).toLowerCase(),
+          page: (i + 1).toString()
+        },
+        props: { type, page: i + 1 },
+      }));
+    })
+    .toArray();
+}
+
+const { type, page } = Astro.props;
+
+const typeTitle = getTypeTitle(type);
+
+import RecommendedLayout from "@layouts/Recommended.astro";
+---
+
+<RecommendedLayout
+  title={`${typeTitle} - Page ${page} | Recommended`}
+  description={`Brian D. Adams recommendations for ${typeTitle}`}
+  sourceLink="/src/pages/recommended/[type]/page/[page].astro"
+  type={type}
+  page={page}
+/>

--- a/src/pages/recommended/page/[page].astro
+++ b/src/pages/recommended/page/[page].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const items = await getCollection("recommendations");
+  const pageSize = 24;
+  const totalPages = Math.ceil(items.length / pageSize);
+  
+  return Array.from({ length: totalPages }, (_, i) => ({
+    params: { page: (i + 1).toString() },
+    props: { page: i + 1 },
+  }));
+}
+
+const { page } = Astro.props;
+
+import RecommendedLayout from "@layouts/Recommended.astro";
+---
+
+<RecommendedLayout
+  title={`Page ${page} | Recommended`}
+  description="Brian D. Adams recommendations for various media like podcasts, movies and television."
+  sourceLink="/src/pages/recommended/page/[page].astro"
+  page={page}
+/>

--- a/src/utils/recommended.ts
+++ b/src/utils/recommended.ts
@@ -22,3 +22,20 @@ export function getTagUrlFragment(tag: any) {
 export function getTagName(tag: any) {
   return (typeof tag === "string" || tag instanceof String) ? tag : tag.name;
 }
+
+export function getPaginationInfo(totalItems: number, currentPage: number = 1, pageSize: number = 24) {
+  const totalPages = Math.ceil(totalItems / pageSize);
+  const validCurrentPage = Math.max(1, Math.min(currentPage, totalPages));
+  const startIndex = (validCurrentPage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, totalItems);
+  
+  return {
+    totalPages,
+    currentPage: validCurrentPage,
+    startIndex,
+    endIndex,
+    hasNextPage: validCurrentPage < totalPages,
+    hasPrevPage: validCurrentPage > 1,
+    pageSize
+  };
+}


### PR DESCRIPTION
## Summary
• Add comprehensive pagination system to recommendations section with Previous/Next navigation and page numbers
• Enable efficient browsing of 135+ recommendation items with 24 items per page instead of displaying all at once
• Maintain full compatibility with existing type and tag filtering while adding pagination URLs

## Test plan
- [x] Verify pagination controls appear when more than 24 items exist
- [x] Test Previous/Next button functionality across different page numbers  
- [x] Confirm page number links work correctly with smart ellipsis display
- [x] Validate pagination URLs work for all routes: /recommended/page/2, /recommended/movies/page/3, /recommended/movies/best-of-2024/page/2
- [x] Ensure existing type and tag filtering continues to work with pagination
- [ ] Check responsive design on mobile devices
- [x] Verify build generates all pagination routes correctly

🤖 Generated with [Claude Code](https://claude.ai/code)