### PR TITLE
Update ViewTransitions to ClientRouter for Astro 5.x compatibility

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ import Menu from "@components/Menu.vue";
 import Footer from "@components/Footer.astro";
 import { Head } from "astro-capo";
 
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 import { SEO, type Props as SEOProps } from "astro-seo";
 
 import "@fontsource/ibm-plex-mono/400.css";
@@ -93,7 +93,7 @@ import "../assets/global.scss";
       })(window, document, "clarity", "script", "l1t8b3e7va");
     </script>
 
-    <ViewTransitions fallback="swap" />
+    <ClientRouter fallback="swap" />
   </Head>
   <body>
     {!hideMenu && <Menu client:only="vue" transition:name="menu-link" />}


### PR DESCRIPTION
## Summary
• Replace deprecated ViewTransitions component with ClientRouter for Astro 5.x compatibility
• Eliminate TypeScript deprecation warnings about ViewTransitions being deprecated
• Maintain all existing view transition functionality without breaking changes

## Test plan
- [x] Verify build completes without deprecation warnings (0 errors, 0 warnings, 0 hints)
- [x] Confirm all existing transition:name attributes continue to work unchanged
- [x] Test that page transitions function correctly with ClientRouter
- [x] Validate 875 optimized images and all pages generate successfully

🤖 Generated with [Claude Code](https://claude.ai/code)