### PR TITLE
Suppress build warnings and update Sentry configuration

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,0 +1,5 @@
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "https://c0923b76e81cff946429e3533e2a3ff1@o4506892850233344.ingest.us.sentry.io/4506892851806208",
+});

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,0 +1,5 @@
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "https://c0923b76e81cff946429e3533e2a3ff1@o4506892850233344.ingest.us.sentry.io/4506892851806208",
+});


### PR DESCRIPTION
## Summary
- Move Sentry DSN to dedicated config files to fix deprecation warning
- Disable Sentry telemetry and conditionally enable source map uploads
- Suppress lit-related Rollup warnings during both client and SSR builds

## Test plan
- [x] Run `npm run build` and verify no warnings appear
- [ ] Verify site works correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)