### PR TITLE
Improve type safety, accessibility, and remove linq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "astro-capo": "0.0.1",
         "astro-pagefind": "1.8.5",
         "astro-seo": "1.1.0",
-        "linq": "4.0.3",
         "lit": "3.3.2",
         "preact": "10.28.3",
         "react": "19.2.4",
@@ -11046,15 +11045,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/linq": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/linq/-/linq-4.0.3.tgz",
-      "integrity": "sha512-dP0w2ERJXfVUk6VmmAK+Tz/SxFHwyY7VM6Mrq4fnJmeQf9JNEYFH6qJfV6Qn0N91mfwz2GEE/4S+RDkmDNyUJw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/listhen": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "astro-capo": "0.0.1",
     "astro-pagefind": "1.8.5",
     "astro-seo": "1.1.0",
-    "linq": "4.0.3",
     "lit": "3.3.2",
     "preact": "10.28.3",
     "react": "19.2.4",

--- a/src/components/Embed.astro
+++ b/src/components/Embed.astro
@@ -22,14 +22,25 @@ if (autoplay) {
   apiUrl += "&autoplay=1";
 }
 
-const response = await fetch(apiUrl);
-
-const data = await response.json();
+let html = "";
+try {
+  const response = await fetch(apiUrl);
+  if (!response.ok) {
+    console.error(`Embed fetch failed for ${url}: ${response.status}`);
+  } else {
+    const data = await response.json();
+    html = data.html ?? "";
+  }
+} catch (e) {
+  console.error(`Embed fetch error for ${url}:`, e);
+}
 ---
 
-<div class:list={["embed", { small: small }]}>
-  <Fragment set:html={data.html} />
-</div>
+{html && (
+  <div class:list={["embed", { small: small }]}>
+    <Fragment set:html={html} />
+  </div>
+)}
 
 <style lang="scss">
   .embed.small :global(iframe) {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -16,6 +16,7 @@
               ? 'fa-sharp fa-solid fa-circle-xmark'
               : 'fa-sharp fa-solid fa-bars'
           "
+          aria-hidden="true"
         ></i>
         <span>Menu</span>
       </div>
@@ -57,15 +58,15 @@
           </AnimatedEntrance>
 
           <AnimatedEntrance type="slideInDown" :delay="0.05">
-            <a class="accessory" href="/search/" title="Search">
-              <i class="fa-sharp fa-solid fa-magnifying-glass"></i>
+            <a class="accessory" href="/search/" title="Search" aria-label="Search">
+              <i class="fa-sharp fa-solid fa-magnifying-glass" aria-hidden="true"></i>
             </a>
           </AnimatedEntrance>
 
           <AnimatedEntrance type="slideInDown" :delay="0.07">
-            <div class="accessory" @click="handleClose" title="Close Menu">
-              <i class="fa-sharp fa-solid fa-circle-xmark"></i>
-            </div>
+            <button class="accessory" @click="handleClose" title="Close Menu" aria-label="Close Menu">
+              <i class="fa-sharp fa-solid fa-circle-xmark" aria-hidden="true"></i>
+            </button>
           </AnimatedEntrance>
         </div>
 
@@ -125,6 +126,8 @@ export default {
       isOpen: false,
       buttonPosition: { x: 0, y: 0, width: 0, height: 0, isFloat: true },
       headshotSrc: headshotImage.src,
+      showTimeoutId: null,
+      closeTimeoutId: null,
     };
   },
   computed: {
@@ -186,6 +189,8 @@ export default {
   beforeUnmount() {
     window.removeEventListener("resize", this.updateMenuPosition);
     window.removeEventListener("orientationchange", this.updateMenuPosition);
+    if (this.showTimeoutId) clearTimeout(this.showTimeoutId);
+    if (this.closeTimeoutId) clearTimeout(this.closeTimeoutId);
   },
   methods: {
     handleShow(event) {
@@ -209,7 +214,7 @@ export default {
       this.show = true;
       this.isOpen = true;
 
-      setTimeout(() => {
+      this.showTimeoutId = setTimeout(() => {
         this.shouldAnimate = true;
       }, 50);
     },
@@ -234,7 +239,7 @@ export default {
     handleClose() {
       this.shouldAnimate = false;
       this.isOpen = false;
-      setTimeout(() => {
+      this.closeTimeoutId = setTimeout(() => {
         this.show = false;
       }, 400);
     },
@@ -444,11 +449,22 @@ export default {
     cursor: pointer;
     font-size: 1.35em;
     border-bottom: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    font: inherit;
 
     &:hover {
       color: var(--color-primary);
       text-decoration: none;
       border-bottom: 0;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+      border-radius: 4px;
     }
   }
 
@@ -459,6 +475,12 @@ export default {
     &:hover {
       color: var(--color-primary);
       transition: all 0.1s;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+      border-radius: 4px;
     }
   }
 

--- a/src/components/RecommendedItems.astro
+++ b/src/components/RecommendedItems.astro
@@ -3,7 +3,6 @@ const { type, tag, page } = Astro.props;
 
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 const allMediaCollection = await getCollection("recommendations");
 
@@ -11,17 +10,14 @@ import {
   getTypeTitle,
   getTagUrlFragment,
   getTagName,
+  getTagRank,
   getPaginationInfo,
 } from "@utils/recommended";
 
-const items = Enumerable.from(allMediaCollection)
-  .select((i) => ({ ...i.data, slug: i.id }))
-  .toArray();
+const items = allMediaCollection
+  .map((i) => ({ ...i.data, slug: i.id }));
 
-const types = Enumerable.from(items)
-  .groupBy((i) => i.type)
-  .select((i) => i.first().type)
-  .toArray();
+const types = [...new Set(items.map((i) => i.type))];
 
 function getTypeIcon(type: string) {
   switch (type.toLowerCase()) {
@@ -42,24 +38,25 @@ function getTypeIcon(type: string) {
 
 function getTagsForType() {
   if (!type) return undefined;
-  return Enumerable.from(items)
-    .where((j) => j.type === Astro.props.type && !!j.tags)
-    .selectMany((j) => j.tags as Array<string>)
-    .groupBy((j) => getTagName(j))
-    .select((jg) => jg.key())
-    .orderBy(t => t)
-    .toArray();
+  const allTags = items
+    .filter((j) => j.type === type && !!j.tags)
+    .flatMap((j) => j.tags!);
+  return [...new Set(allTags.map((t) => getTagName(t)))].sort();
 }
 
 const pageSize = 24;
 
-const filteredItems = Enumerable.from(items)
-      .where((i) => !type || i.type === type)
-      .where((i) => !tag || !!i.tags?.some((t : any) => getTagName(t) == tag))
-      .orderBy((i) =>
-        !tag ? 0 : i.tags!.find((t : any) => getTagName(t) === tag).rank
-      )
-      .thenByDescending((i) => i.date).toArray();
+const filteredItems = items
+  .filter((i) => !type || i.type === type)
+  .filter((i) => !tag || !!i.tags?.some((t) => getTagName(t) == tag))
+  .sort((a, b) => {
+    if (tag) {
+      const rankA = getTagRank(a.tags?.find((t) => getTagName(t) === tag)) ?? 0;
+      const rankB = getTagRank(b.tags?.find((t) => getTagName(t) === tag)) ?? 0;
+      if (rankA !== rankB) return rankA - rankB;
+    }
+    return b.date.getTime() - a.date.getTime();
+  });
 
 const currentPage = page || 1;
 const paginationInfo = getPaginationInfo(filteredItems.length, currentPage, pageSize);
@@ -117,17 +114,15 @@ import Pagination from "@components/Pagination.astro";
 
 <div class:list={["items", (type ?? "").toLowerCase()]}>
   {
-    Enumerable.from(filteredItems)
-      .skip(paginationInfo.startIndex)
-      .take(paginationInfo.pageSize)
-      .toArray()
+    filteredItems
+      .slice(paginationInfo.startIndex, paginationInfo.startIndex + paginationInfo.pageSize)
       .map((i, index) => {
         const large = filteredItems.length < 11 || index < 6;
         return (
           <div class:list={["item", { large }]}>
-            {tag && i.tags!.find((t: any) => t.name === tag)?.rank && (
+            {tag && getTagRank(i.tags?.find((t) => getTagName(t) === tag)) && (
               <div class="rank">
-                {i.tags!.find((t: any) => t.name === tag)?.rank}
+                {getTagRank(i.tags?.find((t) => getTagName(t) === tag))}
               </div>
             )}
 
@@ -167,7 +162,7 @@ import Pagination from "@components/Pagination.astro";
                   </span>
                 )}
 
-                {i.tags?.map((t: string) => (
+                {i.tags?.map((t) => (
                   <span class="badge">{getTagName(t)}</span>
                 ))}
               </div>

--- a/src/components/Title/Title.astro
+++ b/src/components/Title/Title.astro
@@ -19,8 +19,9 @@ const heroSpeedAdjustment = 1.3;
 ---
 
 <div id="title-block" class={wrapperClasses}>
-  <a
-    href="javascript:document.getElementById('menu-link')?.click()"
+  <button
+    class="menu-trigger"
+    onclick="document.getElementById('menu-link')?.click()"
     title="Show Menu"
     aria-label="Show Menu"
   >
@@ -53,12 +54,13 @@ const heroSpeedAdjustment = 1.3;
         />
       )
     }
-  </a>
+  </button>
 
   <div class="title">
     <div class="name" transition:name="title-name">
-      <a
-        href="javascript:document.getElementById('menu-link')?.click()"
+      <button
+        class="menu-trigger"
+        onclick="document.getElementById('menu-link')?.click()"
         aria-label="Show Menu"
       >
         <span class="bracket">
@@ -113,11 +115,12 @@ const heroSpeedAdjustment = 1.3;
             )
           }
         </span>
-      </a>
+      </button>
     </div>
     <div class="desc" transition:name="title-desc">
-      <a
-        href="javascript:document.getElementById('menu-link')?.click()"
+      <button
+        class="menu-trigger"
+        onclick="document.getElementById('menu-link')?.click()"
         aria-label="Show Menu"
       >
         <span class="bracket">
@@ -204,7 +207,7 @@ const heroSpeedAdjustment = 1.3;
             )
           }
         </span>
-      </a>
+      </button>
     </div>
     {
       hero && (
@@ -273,6 +276,17 @@ const heroSpeedAdjustment = 1.3;
   a {
     text-decoration: none;
     color: var(--color-link);
+  }
+
+  .menu-trigger {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-align: inherit;
   }
 
   .name {

--- a/src/components/Typer.vue
+++ b/src/components/Typer.vue
@@ -34,6 +34,7 @@ export default {
     return {
       display: this.hiddenOnStart ? "" : " ",
       remainingTime: this.duration,
+      timeoutId: null,
     };
   },
   beforeMount() {
@@ -44,7 +45,10 @@ export default {
       this.display = this.text;
   },
   mounted() {
-    setTimeout(this.addNextChar, this.delay);
+    this.timeoutId = setTimeout(this.addNextChar, this.delay);
+  },
+  beforeUnmount() {
+    if (this.timeoutId) clearTimeout(this.timeoutId);
   },
   computed: {
     isComplete() {
@@ -74,7 +78,7 @@ export default {
         this.handleComplete();
         return;
       }
-      setTimeout(this.addNextChar, this.charDurations[this.display.length - 1]);
+      this.timeoutId = setTimeout(this.addNextChar, this.charDurations[this.display.length - 1]);
     },
     handleComplete() {
       if (this.once) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -58,7 +58,10 @@ const recommendationsCollection = defineCollection({
     z.object({
       title: z.string(),
       image: image(),
-      tags: z.array(z.any()).optional(),
+      tags: z.array(z.union([
+        z.string(),
+        z.object({ name: z.string(), rank: z.number().optional() }),
+      ])).optional(),
       type: z.enum(["Podcast", "Movie", "TV", "Music", "App"]),
       link: z.string().url(),
       date: z.date(),

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,7 +1,6 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 import Layout from "@layouts/Layout.astro";
 
@@ -10,10 +9,9 @@ import { getReadingTime } from "@utils/readingTime";
 
 const allBlogCollection = await getCollection("blog");
 
-const blogItems = Enumerable.from(allBlogCollection)
-  .select((i) => ({ ...i.data, slug: i.id, body: i.body }))
-  .orderByDescending((a) => a.pubDate)
-  .toArray();
+const blogItems = allBlogCollection
+  .map((i) => ({ ...i.data, slug: i.id, body: i.body }))
+  .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
 ---
 
 <Layout

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -5,14 +5,12 @@ import Layout from "@layouts/Layout.astro";
 import Typer from "@components/Typer.vue";
 
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 const allPortfolioCollection = await getCollection("portfolio");
 
-const portfolioItems = Enumerable.from(allPortfolioCollection)
-  .select((i) => ({ ...i.data, slug: i.id }))
-  .orderByDescending((a) => a.year)
-  .toArray();
+const portfolioItems = allPortfolioCollection
+  .map((i) => ({ ...i.data, slug: i.id }))
+  .sort((a, b) => b.year - a.year);
 ---
 
 <Layout

--- a/src/pages/recommended/[type]/[tag]/index.astro
+++ b/src/pages/recommended/[type]/[tag]/index.astro
@@ -1,32 +1,26 @@
 ---
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 import { getTypeTitle, getTagUrlFragment, getTagName } from "@utils/recommended";
 
 export async function getStaticPaths() {
   const items = await getCollection("recommendations");
 
-  const uniqueTypes = Enumerable.from(items)
-    .groupBy((i) => i.data.type)
-    .select((i) => i.first().data.type);
+  const uniqueTypes = [...new Set(items.map((i) => i.data.type))];
 
-  return uniqueTypes
-    .selectMany((i) =>
-      Enumerable.from(items)
-        .where((j) => j.data.type === i)
-        .selectMany((j) => j.data.tags as Array<string>)
-        .groupBy((j) => getTagName(j))
-        .select((jg) => jg.key())
-        .select((j) => ({
-          params: {
-            type: getTypeTitle(i).toLowerCase(),
-            tag: getTagUrlFragment(j as string),
-          },
-          props: { type: i, tag: j },
-        }))
-    )
-    .toArray();
+  return uniqueTypes.flatMap((type) => {
+    const typeItems = items.filter((j) => j.data.type === type);
+    const allTags = typeItems.flatMap((j) => j.data.tags ?? []);
+    const uniqueTagNames = [...new Set(allTags.map((t) => getTagName(t)))];
+
+    return uniqueTagNames.map((tagName) => ({
+      params: {
+        type: getTypeTitle(type).toLowerCase(),
+        tag: getTagUrlFragment(tagName),
+      },
+      props: { type, tag: tagName },
+    }));
+  });
 }
 
 const { type, tag } = Astro.props;

--- a/src/pages/recommended/[type]/[tag]/page/[page].astro
+++ b/src/pages/recommended/[type]/[tag]/page/[page].astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 import { getTypeTitle, getTagUrlFragment, getTagName } from "@utils/recommended";
 
@@ -8,37 +7,29 @@ export async function getStaticPaths() {
   const items = await getCollection("recommendations");
   const pageSize = 24;
 
-  const uniqueTypes = Enumerable.from(items)
-    .groupBy((i) => i.data.type)
-    .select((i) => i.first().data.type);
+  const uniqueTypes = [...new Set(items.map((i) => i.data.type))];
 
-  return uniqueTypes
-    .selectMany((type) =>
-      Enumerable.from(items)
-        .where((j) => j.data.type === type)
-        .selectMany((j) => j.data.tags as Array<string>)
-        .groupBy((j) => getTagName(j))
-        .selectMany((tagGroup) => {
-          const tag = tagGroup.key();
-          const tagItems = items.filter((i) => 
-            i.data.type === type && 
-            i.data.tags && 
-            i.data.tags.some((t: any) => getTagName(t) === tag)
-          );
-          
-          const totalPages = Math.ceil(tagItems.length / pageSize);
-          
-          return Array.from({ length: totalPages }, (_, i) => ({
-            params: {
-              type: getTypeTitle(type).toLowerCase(),
-              tag: getTagUrlFragment(tag as string),
-              page: (i + 1).toString()
-            },
-            props: { type, tag, page: i + 1 },
-          }));
-        })
-    )
-    .toArray();
+  return uniqueTypes.flatMap((type) => {
+    const typeItems = items.filter((j) => j.data.type === type);
+    const allTags = typeItems.flatMap((j) => j.data.tags ?? []);
+    const uniqueTagNames = [...new Set(allTags.map((t) => getTagName(t)))];
+
+    return uniqueTagNames.flatMap((tagName) => {
+      const tagItems = typeItems.filter((i) =>
+        i.data.tags?.some((t) => getTagName(t) === tagName)
+      );
+      const totalPages = Math.ceil(tagItems.length / pageSize);
+
+      return Array.from({ length: totalPages }, (_, i) => ({
+        params: {
+          type: getTypeTitle(type).toLowerCase(),
+          tag: getTagUrlFragment(tagName),
+          page: (i + 1).toString(),
+        },
+        props: { type, tag: tagName, page: i + 1 },
+      }));
+    });
+  });
 }
 
 const { type, tag, page } = Astro.props;

--- a/src/pages/recommended/[type]/index.astro
+++ b/src/pages/recommended/[type]/index.astro
@@ -1,20 +1,17 @@
 ---
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 import { getTypeTitle } from "@utils/recommended";
 
 export async function getStaticPaths() {
   const items = await getCollection("recommendations");
 
-  return Enumerable.from(items)
-    .groupBy((i) => i.data.type)
-    .select((i) => i.first().data.type)
-    .select((i) => ({
-      params: { type: getTypeTitle(i).toLowerCase() },
-      props: { type: i },
-    }))
-    .toArray();
+  const uniqueTypes = [...new Set(items.map((i) => i.data.type))];
+
+  return uniqueTypes.map((type) => ({
+    params: { type: getTypeTitle(type).toLowerCase() },
+    props: { type },
+  }));
 }
 
 const { type } = Astro.props;

--- a/src/pages/recommended/[type]/page/[page].astro
+++ b/src/pages/recommended/[type]/page/[page].astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from "astro:content";
-import Enumerable from "linq";
 
 import { getTypeTitle } from "@utils/recommended";
 
@@ -8,22 +7,20 @@ export async function getStaticPaths() {
   const items = await getCollection("recommendations");
   const pageSize = 24;
 
-  return Enumerable.from(items)
-    .groupBy((i) => i.data.type)
-    .selectMany((typeGroup) => {
-      const type = typeGroup.first().data.type;
-      const typeItems = typeGroup.toArray();
-      const totalPages = Math.ceil(typeItems.length / pageSize);
-      
-      return Array.from({ length: totalPages }, (_, i) => ({
-        params: { 
-          type: getTypeTitle(type).toLowerCase(),
-          page: (i + 1).toString()
-        },
-        props: { type, page: i + 1 },
-      }));
-    })
-    .toArray();
+  const uniqueTypes = [...new Set(items.map((i) => i.data.type))];
+
+  return uniqueTypes.flatMap((type) => {
+    const typeItems = items.filter((i) => i.data.type === type);
+    const totalPages = Math.ceil(typeItems.length / pageSize);
+
+    return Array.from({ length: totalPages }, (_, i) => ({
+      params: {
+        type: getTypeTitle(type).toLowerCase(),
+        page: (i + 1).toString(),
+      },
+      props: { type, page: i + 1 },
+    }));
+  });
 }
 
 const { type, page } = Astro.props;

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -10,7 +10,6 @@ import ResumeSkillBlock from "@components/Resume/ResumeSkillBlock.astro";
 import ResumeExperienceBlock from "@components/Resume/ResumeExperienceBlock.astro";
 
 import { getEntry, getCollection, render } from "astro:content";
-import Enumerable from "linq";
 
 const profileEntryPromise = getEntry("resume", "profile");
 const educationEntryPromise = getEntry("resume", "education");
@@ -21,12 +20,10 @@ const experienceCollectionPromise = getCollection("resumeExperience");
 const profileEntry = await profileEntryPromise;
 const educationEntry = await educationEntryPromise;
 const certsEntry = await certsEntryPromise;
-const skillsEntries = Enumerable.from(await skillCollectionPromise).orderBy(
-  (a) => a.data.order
-);
-const experienceEntries = Enumerable.from(
-  await experienceCollectionPromise
-).orderByDescending((a) => a.data.startDate);
+const skillsEntries = (await skillCollectionPromise)
+  .sort((a, b) => a.data.order - b.data.order);
+const experienceEntries = (await experienceCollectionPromise)
+  .sort((a, b) => b.data.startDate.localeCompare(a.data.startDate));
 
 const profileRendered = profileEntry ? await render(profileEntry) : null;
 const educationRendered = educationEntry ? await render(educationEntry) : null;
@@ -63,7 +60,7 @@ const CertsContent = certsRendered?.Content;
         </Collapser>
 
         <Collapser client:load title="Work Experience">
-          {experienceEntries.select((e) => <ResumeExperienceBlock entry={e} />)}
+          {experienceEntries.map((e) => <ResumeExperienceBlock entry={e} />)}
         </Collapser>
 
         <Collapser client:load title={educationEntry?.data.title}>
@@ -76,7 +73,7 @@ const CertsContent = certsRendered?.Content;
 
         <Collapser client:load title="Skills">
           <ResumeSkillGrid>
-            {skillsEntries.select((e) => <ResumeSkillBlock entry={e} />)}
+            {skillsEntries.map((e) => <ResumeSkillBlock entry={e} />)}
           </ResumeSkillGrid>
         </Collapser>
       </ResumeHighlighter>

--- a/src/utils/recommended.ts
+++ b/src/utils/recommended.ts
@@ -15,12 +15,19 @@ export function getTypeTitle(type: string) {
   }
 }
 
-export function getTagUrlFragment(tag: any) {
+export type Tag = string | { name: string; rank?: number };
+
+export function getTagUrlFragment(tag: Tag) {
   return getTagName(tag).replaceAll(" ", "-").toLowerCase();
 }
 
-export function getTagName(tag: any) {
-  return (typeof tag === "string" || tag instanceof String) ? tag : tag.name;
+export function getTagName(tag: Tag): string {
+  return typeof tag === "string" ? tag : tag.name;
+}
+
+export function getTagRank(tag: Tag | undefined): number | undefined {
+  if (!tag || typeof tag === "string") return undefined;
+  return tag.rank;
 }
 
 export function getPaginationInfo(totalItems: number, currentPage: number = 1, pageSize: number = 24) {


### PR DESCRIPTION
## Summary
- **Type safety**: Replace `z.any()` tag schema with a proper `string | { name, rank }` union type. Add typed `Tag` export, `getTagRank` helper, and remove all `as any` casts across recommendation pages.
- **Memory leaks**: Store `setTimeout` IDs and clear them in `beforeUnmount` for `Typer.vue` and `Menu.vue`.
- **Error handling**: Wrap `Embed.astro` fetch in try/catch with `response.ok` check so a failed embed API call no longer crashes the build.
- **Accessibility**: Replace 3 `javascript:` protocol links with semantic `<button>` elements in `Title.astro`. Add `aria-hidden="true"` to decorative `<i>` icons, `aria-label` to icon-only buttons, convert close menu `<div>` to `<button>`, and add `:focus-visible` styles in `Menu.vue`.
- **Remove linq dependency**: Replace all 8 files using `linq` (`Enumerable`) with native `.map()`, `.filter()`, `.sort()`, `.flatMap()`, and `Set` for deduplication. Uninstall the package.

## Test plan
- [x] `npm run build` passes with 0 errors, 0 warnings, 0 hints
- [ ] Verify recommended pages render correctly with proper filtering/sorting
- [ ] Verify ranked tag items (e.g. "Best of 2019") still display rank badges and sort correctly
- [ ] Verify menu opens/closes properly and keyboard focus indicators are visible
- [ ] Verify title block buttons still trigger the menu on click
- [ ] Verify embed components gracefully handle API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)