### PR TITLE
chore(deps): bump typescript 5.9.3 → 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "sass": "1.99.0",
         "solid-js": "1.9.12",
         "svelte": "5.55.5",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vue": "3.5.34"
       }
     },
@@ -14646,6 +14646,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/precinct/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -16702,9 +16715,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sass": "1.99.0",
     "solid-js": "1.9.12",
     "svelte": "5.55.5",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vue": "3.5.34"
   }
 }


### PR DESCRIPTION
## Summary
- `typescript` 5.9.3 → 6.0.3 (major)
- Pinned exact (no `^`/`~`)

## Notes
- `astro check` passes: 0 errors / 0 warnings / 0 hints
- Astro integrations (`@astrojs/svelte`, `@astrojs/check`, etc.) still declare `typescript@^5.3.3` as a peer, so `npm install` prints peer-dep warnings. Install, build, and SSR output are unaffected.

## Test plan
- [x] `npm run build` succeeds locally
- [ ] Netlify deploy preview builds cleanly
- [ ] Spot-check a few rendered pages on the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)