### PR TITLE
fix(sentry): move dsn to SDK config files to silence deprecation warning

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,7 +24,6 @@ export default defineConfig({
     prefetchAll: true
   },
   integrations: [vue(), mdx(), sitemap(), sentry({
-    dsn: "https://c0923b76e81cff946429e3533e2a3ff1@o4506892850233344.ingest.us.sentry.io/4506892851806208",
     sourceMapsUploadOptions: {
       project: "bdadamsdotcom",
       authToken: SENTRY_AUTH_TOKEN,

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,0 +1,5 @@
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "https://c0923b76e81cff946429e3533e2a3ff1@o4506892850233344.ingest.us.sentry.io/4506892851806208",
+});

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,0 +1,5 @@
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  dsn: "https://c0923b76e81cff946429e3533e2a3ff1@o4506892850233344.ingest.us.sentry.io/4506892851806208",
+});


### PR DESCRIPTION
## Problem

Netlify builds log this warning on every build:

> [WARN] [@sentry/astro] You passed in additional options (dsn) to the Sentry integration. This is deprecated and will stop working in a future version. Instead, configure the Sentry SDK in your `sentry.client.config.(js|ts)` or `sentry.server.config.(js|ts)` files.

`@sentry/astro` v10 no longer accepts runtime SDK options (like `dsn`) on the integration.

## Fix

- Add `sentry.client.config.js` and `sentry.server.config.js`, each calling `Sentry.init({ dsn })`.
- Remove the inline `dsn` from the `sentry()` integration in `astro.config.mjs`, keeping the build-time `sourceMapsUploadOptions` there.

The DSN is a public value (it ships in the client bundle by design), so it's fine in `sentry.client.config.js`.

## Verification

`bun run build` completes with `0 errors / 0 warnings` from Sentry and no longer emits the deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)